### PR TITLE
Cleanup test debug output

### DIFF
--- a/tests/ProvisionTeamsPhoneUsers.Tests.ps1
+++ b/tests/ProvisionTeamsPhoneUsers.Tests.ps1
@@ -2,9 +2,6 @@ $scriptPath = Join-Path $PSScriptRoot '..' 'ProvisionTeamsPhoneUsers.ps1'
 $usersCsv   = Join-Path $PSScriptRoot 'data' 'Users.csv'
 $didsCsv    = Join-Path $PSScriptRoot 'data' 'dids.csv'
 
-# Debugging: Verify resolved script path
-Write-Host "Resolved script path: $scriptPath"
-
 # Check if the script file exists
 if (-not (Test-Path $scriptPath)) {
     Throw "Script file not found at path: $scriptPath"


### PR DESCRIPTION
## Summary
- remove leftover Write-Host debug lines from test file

## Testing
- `pwsh -NoLogo -Command "Invoke-Pester tests/ProvisionTeamsPhoneUsers.Tests.ps1 -Passthru"` *(fails: `pwsh` not found)*